### PR TITLE
Add bundle generation for multiple metrics

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
-  "extends": ["bloq", "bloq/node", "prettier"],
+  "extends": ["bloq", "bloq/node", "bloq/esm", "prettier"],
+  "ignorePatterns": ["out.js"],
   "globals": {
     "UrlFetchApp": "readonly",
     "SpreadsheetApp": "readonly"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .vscode
 node_modules
+out.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,11 @@
         "eslint-config-bloq": "4.6.1",
         "husky": "9.1.7",
         "lint-staged": "16.1.0",
-        "prettier": "3.5.3"
+        "prettier": "3.5.3",
+        "rollup": "4.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@altano/repository-tools": {
@@ -575,6 +579,160 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.0.0.tgz",
+      "integrity": "sha512-rN3qt1JzOx0v7JWyK68zkb3yf1k1f1OhhHR0i7vLlGlediTtM3FKsOkestQN6HwJ9nEaP3KxPHxH5Xv7yr6f4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.0.0.tgz",
+      "integrity": "sha512-dcdg6Zp2bqIS/+2FHhdSS+lbcySufP2fYYoXkDa4W6uHE22L15psftdQZtFhxvvqRWPD1HsK0xIj5f07zuujkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.0.0.tgz",
+      "integrity": "sha512-mOz75DpOOHGk4+xYbh1E23vmSOrOqskTwq9s/e2Z46eYbTZ0+s/UVoS42cLG8dUe6enF2Xh3hTtiIEzLhO9kmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.0.0.tgz",
+      "integrity": "sha512-rEBuHQ2ejl9gb0//19F88gR7Z9HY2kcCX8jT5LhCHqGqAvlloETXO1FD7DKEdqGz98UtJy6pVAxxeVBN4tlWag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.0.0.tgz",
+      "integrity": "sha512-W4Elp0SGWqWOkdgoYniOp6ERrhHYRfMPikUZmnU/kAdLXQ9p0M0meF648Z6Y7ClHJr8pIQpcCdmr7E2h8Kn7Fw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.0.0.tgz",
+      "integrity": "sha512-/BTevM/UKprMJgFse0nm+YXQ83iDqArru+k3kZtQlvaNMWdkLcyscOP8SwWPpR0CJuLlXr8Gtpps+EgH3TUqLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.0.0.tgz",
+      "integrity": "sha512-Pz2FD/4FUZM98+rcpuGAJgatW5/dW/pXXrbanjtir38EYqqmdVc0odHwqlQ+KFY2C5P+B6PJO5vom8PmJQLdug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.0.0.tgz",
+      "integrity": "sha512-Xs2tOshU5MD7nK5WnaSBUwiFdBlMtyKdXOOnBno4IRbDIyrjLtx9lnSIO47FNP0LtpGfyOcsK/lE/ZsLlnXyIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.0.0.tgz",
+      "integrity": "sha512-h2r04SsqVMbmaIRSMN3HKQLYpKewJ7rWQx1SwEZQMeXRkecWFBBNOfoB3iMlvvUfc3VUOonR/3Dm/Op6yOD2Lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.0.0.tgz",
+      "integrity": "sha512-1pl05L51RbVLnqZTEpbgG2RxeS7VLysF7vhU8v1EOAMqbLzko64r8+S2SxsNDKODsgusFqHO8rc3w+G9VUjodw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.0.0.tgz",
+      "integrity": "sha512-GDi4TkL95/J0ven1wt+q2cfdg1k9UEIQiF58lSC36KUdA0xtlqgLPEDlNAhu6NTXJ491eiZ71lQbLu1D7hlz9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -609,6 +767,15 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3661,6 +3828,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6068,6 +6250,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.0.0.tgz",
+      "integrity": "sha512-dtlkoIdp/g2glVlQb6FzhMAMzhMYVIJ3KLGjhWKkwz/ambEuHeVZ7Eg6GALhHZOsDRD+ZWSjnUikZXPyb22puQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.0.0",
+        "@rollup/rollup-android-arm64": "4.0.0",
+        "@rollup/rollup-darwin-arm64": "4.0.0",
+        "@rollup/rollup-darwin-x64": "4.0.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.0.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.0.0",
+        "@rollup/rollup-linux-x64-gnu": "4.0.0",
+        "@rollup/rollup-linux-x64-musl": "4.0.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.0.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.0.0",
+        "@rollup/rollup-win32-x64-msvc": "4.0.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "repository": "hemilabs/metrics-utilities",
   "scripts": {
+    "build": "rollup -c",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
     "lint": "eslint --cache .",
@@ -23,9 +24,11 @@
     "eslint-config-bloq": "4.6.1",
     "husky": "9.1.7",
     "lint-staged": "16.1.0",
-    "prettier": "3.5.3"
+    "prettier": "3.5.3",
+    "rollup": "4.0.0"
   },
   "engines": {
     "node": ">=20"
-  }
+  },
+  "type": "module"
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,13 @@
+export default {
+  input: "src/index.js",
+  output: {
+    file: "out.js",
+    format: "esm",
+    generatedCode: "es2015",
+    preserveModules: false,
+  },
+  // Not ideal, but the build may remove functions that are declared but not used.
+  // However, Google App Scripts uses the declarations as entry points. With Treeshake enabled,
+  // the declarations would be removed.
+  treeshake: false,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,16 @@
+// This file is the entry point using ESM. However, on build. time,
+// the script will consist of only one file, and it will run in the context of a Google Sheets document
+// using Google Apps Script. Note that async code is not supported. CommonJs ("require")
+// or ESM ("import") are not supported either (but are removed by the build process). For similar
+// reasons, no dependency should be added, to keep this script as simple as possible.
+// As part of the build, everything ends up in a big plain javascript file (out.js).
+// That script can be copied into a Google App Script and should run without any change.
+// The output script is not minified to it is easier to debug in the Google App Script editor.
+import { addTvlInfo } from "./stakeTvl";
+
+// This is the main entry point for Google App Script. Do not remove it
+// Google App Script needs the declaration only to use it as an entry point
+// eslint-disable-next-line no-unused-vars
+function updateMetrics() {
+  addTvlInfo();
+}

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,9 +1,3 @@
-// This script runs in the context of a Google Sheets document
-// using Google Apps Script. Note that async code is not supported. CommonJs ("require")
-// or ESM ("import") are not supported either - so it's only a big plain javascript file.
-// This script can be copied into a Google App Script and should run without any change.
-"use strict";
-
 const pricesUrl = "https://token-prices.hemi.xyz/";
 const stakeUrl = "https://subgraph.hemi.xyz/43111/staked";
 const tokenListUrl =
@@ -188,9 +182,7 @@ function getTvlFormula({ headers, lastRow, sheet }) {
   return `=SUM(${startRange.getA1Notation()}:${endRange.getA1Notation()})`;
 }
 
-// This is the function entry point, and it is configured to run from Google Sheets
-// eslint-disable-next-line no-unused-vars
-function addTvlInfo() {
+export function addTvlInfo() {
   const stakeSheet =
     SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Stake TVL");
 


### PR DESCRIPTION
Currently, this repo has only one file to calculate Stake TVL. However, as further metrics will be added, code separation will be vital to understand better what the code is doing. This PR then allows us to write the code using `ESM`, and then using `rollup` to generate a one-file script that will be published into Google App Scripts. Note that there still are restrictions (as no async code) as this is a subset of JS.

The script that will be generated as part of this PR  is fairly similar to the one that previously was "the only" script file. This should allow us to create new files for the incoming metrics that we want to calculate, while still being able to debug in the Google App Script Editor.

I thought of using `esbuild`, but it did not preserve the comments. That was a problem, as the comments were useful for debugging in the mentioned editor.

I did not split `addStakeTvl` for the time being.. as I need some functions from there into others, I will do so.