### PR TITLE
Tunnel volume pre changes

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -1,0 +1,4 @@
+export const getDate = function () {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,12 @@
 // As part of the build, everything ends up in a big plain javascript file (out.js).
 // That script can be copied into a Google App Script and should run without any change.
 // The output script is not minified to it is easier to debug in the Google App Script editor.
-import { addTvlInfo } from "./stakeTvl";
+import { createStakeTvl } from "./stakeTvl";
 
 // This is the main entry point for Google App Script. Do not remove it
 // Google App Script needs the declaration only to use it as an entry point
 // eslint-disable-next-line no-unused-vars
 function updateMetrics() {
+  const { addTvlInfo } = createStakeTvl();
   addTvlInfo();
 }

--- a/src/prices.js
+++ b/src/prices.js
@@ -1,0 +1,6 @@
+const pricesUrl = "https://token-prices.hemi.xyz/";
+
+export const getPrices = function () {
+  const { prices } = JSON.parse(UrlFetchApp.fetch(pricesUrl).getContentText());
+  return prices;
+};

--- a/src/prices.js
+++ b/src/prices.js
@@ -4,3 +4,64 @@ export const getPrices = function () {
   const { prices } = JSON.parse(UrlFetchApp.fetch(pricesUrl).getContentText());
   return prices;
 };
+
+// As some tokens do not have their own prices, they map into the prices of these tokens
+// Based on https://github.com/hemilabs/ui-monorepo/blob/main/portal/tokenList/stakeTokens.ts
+const priceMaps = {
+  btc: [
+    // btBTC
+    "0x93919784C523f39CACaa98Ee0a9d96c3F32b593e",
+    // enzoBTC
+    "0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a",
+    // hemiBTC
+    "0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28",
+    // iBTC
+    "0x8154Aaf094c2f03Ad550B6890E1d4264B5DdaD9A",
+    // mBTC
+    "0x0Af3EC6F9592C193196bEf220BC0Ce4D9311527D",
+    // oBTC
+    "0xe3C0FF176eF92FC225096C6d1788cCB818808b35",
+    // stBTC
+    "0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3",
+    // suBTC
+    "0xe85411C030fB32A9D8b14Bbbc6CB19417391F711",
+    // tBTC v2
+    "0x12B6e6FC45f81cDa81d2656B974E8190e4ab8D93",
+    // uBTC
+    "0x78E26E8b953C7c78A58d69d8B9A91745C2BbB258",
+    // uniBTC
+    "0xF9775085d726E782E83585033B58606f7731AB18",
+    // ynCoBTCk
+    "0x8970a6A9Eae065aA81a94E86ebCAF4F3d4dd6DA1",
+  ],
+  eth: [
+    // egETH
+    "0x027a9d301FB747cd972CFB29A63f3BDA551DFc5c",
+    // rsETH
+    "0xc3eACf0612346366Db554C991D7858716db09f58",
+  ],
+  usdc: [
+    // satUSD
+    "0xb4818BB69478730EF4e33Cc068dD94278e2766cB",
+    // stargate USDC
+    "0xad11a8BEb98bbf61dbb1aa0F6d6F2ECD87b35afA",
+  ],
+  usdt: [
+    // VUSD
+    "0x7A06C4AeF988e7925575C50261297a946aD204A8",
+  ],
+};
+
+export const addUsdRate = (prices) =>
+  function (token) {
+    // some tokens do not adjust to symbol, so they use this mapping instead
+    const symbol =
+      Object.keys(priceMaps).find((priceSymbol) =>
+        priceMaps[priceSymbol].includes(token.address),
+      ) || token.symbol;
+    return {
+      ...token,
+      priceSymbol: symbol.toUpperCase(),
+      usdRate: prices[symbol.toUpperCase()],
+    };
+  };

--- a/src/spreadsheets.js
+++ b/src/spreadsheets.js
@@ -1,0 +1,14 @@
+/**
+ * This function checks the complete spreadsheet, and gets the last row with data.
+ * As usually each metric takes one entire row, the last row + 1 will give the row
+ * where to paste the next snapshot.
+ */
+export function getLastRowWithData(sheet) {
+  const rowsWithValue = sheet
+    .getRange("A:A")
+    .getValues()
+    .map((row) => row[0])
+    .filter(String); // Remove empty rows
+  // Spreadsheets are 1-indexed, so they match the length
+  return rowsWithValue.length || 1;
+}

--- a/src/spreadsheets.js
+++ b/src/spreadsheets.js
@@ -12,3 +12,17 @@ export function getLastRowWithData(sheet) {
   // Spreadsheets are 1-indexed, so they match the length
   return rowsWithValue.length || 1;
 }
+
+const usdSuffix = "_usd";
+
+/**
+ * Deterministically generates the headers for a spreadsheet, based on the symbol.
+ */
+export const generateTokenHeaders = (tokens) => [
+  ...new Set(
+    tokens
+      .map(({ symbol }) => symbol)
+      .sort()
+      .concat(tokens.map(({ symbol }) => `${symbol}${usdSuffix}`).sort()),
+  ),
+];

--- a/src/spreadsheets.js
+++ b/src/spreadsheets.js
@@ -26,3 +26,37 @@ export const generateTokenHeaders = (tokens) => [
       .concat(tokens.map(({ symbol }) => `${symbol}${usdSuffix}`).sort()),
   ),
 ];
+
+/**
+ * This function writes a list of headers into a spreadsheet. If headers already exist,
+ * it adds new columns to match the new ordered list. Note that it expects a deterministic sorted list of headers.
+ */
+export const writeHeaders = function ({ headers, sheet }) {
+  const lastRowWithData = getLastRowWithData(sheet);
+  // if there are no headers, this is the first time, so we must write all of them
+  // note that
+  if (lastRowWithData === 1) {
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    return;
+  }
+  // let's match the current headers with the ones calculated. If there's a mismatch, it means
+  // a new header appeared. If so, we must add a new column.
+  // if there are headers, we must check if there's any new header that must be added
+  // by default, add them to the right, and default all values to zero
+  for (let columnIndex = 1; columnIndex <= headers.length; columnIndex++) {
+    const headerCell = sheet.getRange(1, columnIndex);
+    const headerValue = headers[columnIndex - 1];
+    const currentHeaderValue = headerCell.getValue();
+    if (currentHeaderValue === headerValue) {
+      // values match - nothing to do here
+      continue;
+    }
+    // there's a mismatch, so we must
+    // 1. Add a new column to the right
+    sheet.insertColumnAfter(columnIndex - 1);
+    // 2. Set the header for the new column
+    sheet.getRange(1, columnIndex).setValue(headerValue);
+    // 3. Fill all the previous values with "0"
+    sheet.getRange(2, columnIndex, lastRowWithData - 1, 1).setValue(0);
+  }
+};

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,7 +1,7 @@
+import { getTokenList } from "./tokenList";
+
 const pricesUrl = "https://token-prices.hemi.xyz/";
 const stakeUrl = "https://subgraph.hemi.xyz/43111/staked";
-const tokenListUrl =
-  "https://raw.githubusercontent.com/hemilabs/token-list/master/src/hemi.tokenlist.json";
 
 const usdSuffix = "_usd";
 // Skip Date and TVL columns
@@ -81,12 +81,6 @@ const addUsdRate = (prices) =>
       usdRate: prices[symbol.toUpperCase()],
     };
   };
-
-// stake only uses Mainnet data
-const getTokenList = () =>
-  JSON.parse(UrlFetchApp.fetch(tokenListUrl).getContentText()).tokens.filter(
-    (token) => token.chainId === 43111,
-  );
 
 /**
  * This functions the complete spreadsheet, and gets the last row with data.

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,5 +1,6 @@
 import { getPrices } from "./prices";
 import { getTokenList } from "./tokenList";
+import { addTokenMetadata } from "./tokens";
 
 const stakeUrl = "https://subgraph.hemi.xyz/43111/staked";
 
@@ -53,20 +54,6 @@ const priceMaps = {
     "0x7A06C4AeF988e7925575C50261297a946aD204A8",
   ],
 };
-
-const addTokenMetadata = (tokenList) =>
-  function (stakeToken) {
-    const { address, decimals, symbol } = tokenList.find(
-      (tokenDefinition) =>
-        tokenDefinition.address.toLowerCase() === stakeToken.id.toLowerCase(),
-    );
-    return {
-      ...stakeToken,
-      address,
-      decimals,
-      symbol,
-    };
-  };
 
 const addUsdRate = (prices) =>
   function (stakeToken) {

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -3,125 +3,129 @@ import { getLastRowWithData } from "./spreadsheets";
 import { getTokenList } from "./tokenList";
 import { addTokenMetadata } from "./tokens";
 
-const stakeUrl = "https://subgraph.hemi.xyz/43111/staked";
+export const createStakeTvl = function () {
+  const stakeUrl = "https://subgraph.hemi.xyz/43111/staked";
 
-const usdSuffix = "_usd";
-// Skip Date and TVL columns
-const columnOffset = 2;
+  const usdSuffix = "_usd";
+  // Skip Date and TVL columns
+  const columnOffset = 2;
 
-function getDate() {
-  const now = new Date();
-  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
-}
-
-/**
- * Deterministically generates the headers for the TVL sheet, based on the symbol.
- */
-const getHeaders = (stakeData) => [
-  ...new Set(
-    stakeData
-      .map(({ symbol }) => symbol)
-      .sort()
-      .concat(stakeData.map(({ symbol }) => `${symbol}${usdSuffix}`).sort()),
-  ),
-];
-
-function writeHeaders({ headers, sheet }) {
-  const lastRowWithData = getLastRowWithData(sheet);
-  // if there are no headers, this is the first time, so we must write all of them
-  // note that
-  if (lastRowWithData === 1) {
-    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
-    return;
+  function getDate() {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
   }
-  // let's match the current headers with the ones calculated. If there's a mismatch, it means
-  // a new stake token appeared. If so, we must add a new column
-  // if there are headers, we must check if there's any new header that must be added
-  // by default, add them to the right, and default all values to zero
-  for (let columnIndex = 1; columnIndex <= headers.length; columnIndex++) {
-    const headerCell = sheet.getRange(1, columnIndex);
-    const headerValue = headers[columnIndex - 1];
-    const currentHeaderValue = headerCell.getValue();
-    if (currentHeaderValue === headerValue) {
-      // values match - nothing to do here
-      continue;
-    }
-    // there's a mismatch, so we must
-    // 1. Add a new column to the right
-    sheet.insertColumnAfter(columnIndex - 1);
-    // 2. Set the header for the new column
-    sheet.getRange(1, columnIndex).setValue(headerValue);
-    // 3. Fill all the previous values with "0"
-    sheet.getRange(2, columnIndex, lastRowWithData - 1, 1).setValue(0);
-  }
-}
 
-const getValues = ({ headers, lastRow, sheet, stakeData }) =>
-  headers.map(function (header) {
-    if (!header.endsWith(usdSuffix)) {
-      const { decimals, totalStaked } = stakeData.find(
-        ({ symbol }) => symbol === header,
-      );
-      return `=${totalStaked}/(10^${decimals})`;
-    }
-    // it's a usd price, so it should just multiply the usd rate with the token
-    const baseSymbol = header.replace(usdSuffix, "");
-    const baseTokenColumn = headers.findIndex((h) => h === baseSymbol);
-    const { usdRate } = stakeData.find(({ symbol }) => symbol === baseSymbol);
-    // sheets are 1-index based
-    const range = sheet.getRange(
-      lastRow + 1,
-      baseTokenColumn + columnOffset + 1,
-    );
-    return `=${range.getA1Notation()}*${usdRate}`;
-  });
-
-function getTvlFormula({ headers, lastRow, sheet }) {
-  // the TVL should sum all the columns that end with the USD suffix. All suffixed tokens
-  // must be at the end, so by finding the first usd token, we can get the whole range
-  // Remember, sheets are 1-index based
-  const startUsdIndex =
-    headers.findIndex((header) => header.endsWith(usdSuffix)) + 1;
-  const endUsdIndex = headers.length;
-  const startRange = sheet.getRange(lastRow + 1, startUsdIndex);
-  const endRange = sheet.getRange(lastRow + 1, endUsdIndex);
-  return `=SUM(${startRange.getA1Notation()}:${endRange.getA1Notation()})`;
-}
-
-export function addTvlInfo() {
-  const stakeSheet =
-    SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Stake TVL");
-
-  // gather all the information we need
-  const prices = getPrices();
-  const { staked } = JSON.parse(UrlFetchApp.fetch(stakeUrl).getContentText());
-
-  const tokenList = getTokenList();
-
-  const stakeData = staked
-    .map(addTokenMetadata(tokenList))
-    .map(addUsdRate(prices));
-
-  const symbolHeaders = getHeaders(stakeData);
-
-  const lastRow = getLastRowWithData(stakeSheet);
-
-  const headers = ["Date", "TVL", ...symbolHeaders];
-
-  writeHeaders({ headers, sheet: stakeSheet });
-
-  const tokenValues = getValues({
-    headers: symbolHeaders,
-    lastRow,
-    sheet: stakeSheet,
-    stakeData,
-  });
-
-  const values = [
-    getDate(),
-    getTvlFormula({ headers, lastRow, sheet: stakeSheet }),
-    ...tokenValues,
+  /**
+   * Deterministically generates the headers for the TVL sheet, based on the symbol.
+   */
+  const getHeaders = (stakeData) => [
+    ...new Set(
+      stakeData
+        .map(({ symbol }) => symbol)
+        .sort()
+        .concat(stakeData.map(({ symbol }) => `${symbol}${usdSuffix}`).sort()),
+    ),
   ];
 
-  stakeSheet.getRange(lastRow + 1, 1, 1, values.length).setValues([values]);
-}
+  function writeHeaders({ headers, sheet }) {
+    const lastRowWithData = getLastRowWithData(sheet);
+    // if there are no headers, this is the first time, so we must write all of them
+    // note that
+    if (lastRowWithData === 1) {
+      sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+      return;
+    }
+    // let's match the current headers with the ones calculated. If there's a mismatch, it means
+    // a new stake token appeared. If so, we must add a new column
+    // if there are headers, we must check if there's any new header that must be added
+    // by default, add them to the right, and default all values to zero
+    for (let columnIndex = 1; columnIndex <= headers.length; columnIndex++) {
+      const headerCell = sheet.getRange(1, columnIndex);
+      const headerValue = headers[columnIndex - 1];
+      const currentHeaderValue = headerCell.getValue();
+      if (currentHeaderValue === headerValue) {
+        // values match - nothing to do here
+        continue;
+      }
+      // there's a mismatch, so we must
+      // 1. Add a new column to the right
+      sheet.insertColumnAfter(columnIndex - 1);
+      // 2. Set the header for the new column
+      sheet.getRange(1, columnIndex).setValue(headerValue);
+      // 3. Fill all the previous values with "0"
+      sheet.getRange(2, columnIndex, lastRowWithData - 1, 1).setValue(0);
+    }
+  }
+
+  const getValues = ({ headers, lastRow, sheet, stakeData }) =>
+    headers.map(function (header) {
+      if (!header.endsWith(usdSuffix)) {
+        const { decimals, totalStaked } = stakeData.find(
+          ({ symbol }) => symbol === header,
+        );
+        return `=${totalStaked}/(10^${decimals})`;
+      }
+      // it's a usd price, so it should just multiply the usd rate with the token
+      const baseSymbol = header.replace(usdSuffix, "");
+      const baseTokenColumn = headers.findIndex((h) => h === baseSymbol);
+      const { usdRate } = stakeData.find(({ symbol }) => symbol === baseSymbol);
+      // sheets are 1-index based
+      const range = sheet.getRange(
+        lastRow + 1,
+        baseTokenColumn + columnOffset + 1,
+      );
+      return `=${range.getA1Notation()}*${usdRate}`;
+    });
+
+  function getTvlFormula({ headers, lastRow, sheet }) {
+    // the TVL should sum all the columns that end with the USD suffix. All suffixed tokens
+    // must be at the end, so by finding the first usd token, we can get the whole range
+    // Remember, sheets are 1-index based
+    const startUsdIndex =
+      headers.findIndex((header) => header.endsWith(usdSuffix)) + 1;
+    const endUsdIndex = headers.length;
+    const startRange = sheet.getRange(lastRow + 1, startUsdIndex);
+    const endRange = sheet.getRange(lastRow + 1, endUsdIndex);
+    return `=SUM(${startRange.getA1Notation()}:${endRange.getA1Notation()})`;
+  }
+
+  function addTvlInfo() {
+    const stakeSheet =
+      SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Stake TVL");
+
+    // gather all the information we need
+    const prices = getPrices();
+    const { staked } = JSON.parse(UrlFetchApp.fetch(stakeUrl).getContentText());
+
+    const tokenList = getTokenList();
+
+    const stakeData = staked
+      .map(addTokenMetadata(tokenList))
+      .map(addUsdRate(prices));
+
+    const symbolHeaders = getHeaders(stakeData);
+
+    const lastRow = getLastRowWithData(stakeSheet);
+
+    const headers = ["Date", "TVL", ...symbolHeaders];
+
+    writeHeaders({ headers, sheet: stakeSheet });
+
+    const tokenValues = getValues({
+      headers: symbolHeaders,
+      lastRow,
+      sheet: stakeSheet,
+      stakeData,
+    });
+
+    const values = [
+      getDate(),
+      getTvlFormula({ headers, lastRow, sheet: stakeSheet }),
+      ...tokenValues,
+    ];
+
+    stakeSheet.getRange(lastRow + 1, 1, 1, values.length).setValues([values]);
+  }
+
+  return { addTvlInfo };
+};

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,5 +1,9 @@
 import { addUsdRate, getPrices } from "./prices";
-import { generateTokenHeaders, getLastRowWithData } from "./spreadsheets";
+import {
+  generateTokenHeaders,
+  getLastRowWithData,
+  writeHeaders,
+} from "./spreadsheets";
 import { getTokenList } from "./tokenList";
 import { addTokenMetadata } from "./tokens";
 
@@ -13,36 +17,6 @@ export const createStakeTvl = function () {
   function getDate() {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  }
-
-  function writeHeaders({ headers, sheet }) {
-    const lastRowWithData = getLastRowWithData(sheet);
-    // if there are no headers, this is the first time, so we must write all of them
-    // note that
-    if (lastRowWithData === 1) {
-      sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
-      return;
-    }
-    // let's match the current headers with the ones calculated. If there's a mismatch, it means
-    // a new stake token appeared. If so, we must add a new column
-    // if there are headers, we must check if there's any new header that must be added
-    // by default, add them to the right, and default all values to zero
-    for (let columnIndex = 1; columnIndex <= headers.length; columnIndex++) {
-      const headerCell = sheet.getRange(1, columnIndex);
-      const headerValue = headers[columnIndex - 1];
-      const currentHeaderValue = headerCell.getValue();
-      if (currentHeaderValue === headerValue) {
-        // values match - nothing to do here
-        continue;
-      }
-      // there's a mismatch, so we must
-      // 1. Add a new column to the right
-      sheet.insertColumnAfter(columnIndex - 1);
-      // 2. Set the header for the new column
-      sheet.getRange(1, columnIndex).setValue(headerValue);
-      // 3. Fill all the previous values with "0"
-      sheet.getRange(2, columnIndex, lastRowWithData - 1, 1).setValue(0);
-    }
   }
 
   const getValues = ({ headers, lastRow, sheet, stakeData }) =>

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,5 +1,5 @@
 import { addUsdRate, getPrices } from "./prices";
-import { getLastRowWithData } from "./spreadsheets";
+import { generateTokenHeaders, getLastRowWithData } from "./spreadsheets";
 import { getTokenList } from "./tokenList";
 import { addTokenMetadata } from "./tokens";
 
@@ -14,18 +14,6 @@ export const createStakeTvl = function () {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), now.getDate());
   }
-
-  /**
-   * Deterministically generates the headers for the TVL sheet, based on the symbol.
-   */
-  const getHeaders = (stakeData) => [
-    ...new Set(
-      stakeData
-        .map(({ symbol }) => symbol)
-        .sort()
-        .concat(stakeData.map(({ symbol }) => `${symbol}${usdSuffix}`).sort()),
-    ),
-  ];
 
   function writeHeaders({ headers, sheet }) {
     const lastRowWithData = getLastRowWithData(sheet);
@@ -103,7 +91,7 @@ export const createStakeTvl = function () {
       .map(addTokenMetadata(tokenList))
       .map(addUsdRate(prices));
 
-    const symbolHeaders = getHeaders(stakeData);
+    const symbolHeaders = generateTokenHeaders(stakeData);
 
     const lastRow = getLastRowWithData(stakeSheet);
 

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,6 +1,6 @@
+import { getPrices } from "./prices";
 import { getTokenList } from "./tokenList";
 
-const pricesUrl = "https://token-prices.hemi.xyz/";
 const stakeUrl = "https://subgraph.hemi.xyz/43111/staked";
 
 const usdSuffix = "_usd";
@@ -181,7 +181,7 @@ export function addTvlInfo() {
     SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Stake TVL");
 
   // gather all the information we need
-  const { prices } = JSON.parse(UrlFetchApp.fetch(pricesUrl).getContentText());
+  const prices = getPrices();
   const { staked } = JSON.parse(UrlFetchApp.fetch(stakeUrl).getContentText());
 
   const tokenList = getTokenList();

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,3 +1,4 @@
+import { getDate } from "./date";
 import { addUsdRate, getPrices } from "./prices";
 import {
   generateTokenHeaders,
@@ -13,11 +14,6 @@ export const createStakeTvl = function () {
   const usdSuffix = "_usd";
   // Skip Date and TVL columns
   const columnOffset = 2;
-
-  function getDate() {
-    const now = new Date();
-    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  }
 
   const getValues = ({ headers, lastRow, sheet, stakeData }) =>
     headers.map(function (header) {

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,4 +1,4 @@
-import { getPrices } from "./prices";
+import { addUsdRate, getPrices } from "./prices";
 import { getTokenList } from "./tokenList";
 import { addTokenMetadata } from "./tokens";
 
@@ -7,67 +7,6 @@ const stakeUrl = "https://subgraph.hemi.xyz/43111/staked";
 const usdSuffix = "_usd";
 // Skip Date and TVL columns
 const columnOffset = 2;
-
-// As some tokens do not have their own prices, they map into the prices of these tokens
-// Based on https://github.com/hemilabs/ui-monorepo/blob/main/portal/tokenList/stakeTokens.ts
-const priceMaps = {
-  btc: [
-    // btBTC
-    "0x93919784C523f39CACaa98Ee0a9d96c3F32b593e",
-    // enzoBTC
-    "0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a",
-    // hemiBTC
-    "0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28",
-    // iBTC
-    "0x8154Aaf094c2f03Ad550B6890E1d4264B5DdaD9A",
-    // mBTC
-    "0x0Af3EC6F9592C193196bEf220BC0Ce4D9311527D",
-    // oBTC
-    "0xe3C0FF176eF92FC225096C6d1788cCB818808b35",
-    // stBTC
-    "0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3",
-    // suBTC
-    "0xe85411C030fB32A9D8b14Bbbc6CB19417391F711",
-    // tBTC v2
-    "0x12B6e6FC45f81cDa81d2656B974E8190e4ab8D93",
-    // uBTC
-    "0x78E26E8b953C7c78A58d69d8B9A91745C2BbB258",
-    // uniBTC
-    "0xF9775085d726E782E83585033B58606f7731AB18",
-    // ynCoBTCk
-    "0x8970a6A9Eae065aA81a94E86ebCAF4F3d4dd6DA1",
-  ],
-  eth: [
-    // egETH
-    "0x027a9d301FB747cd972CFB29A63f3BDA551DFc5c",
-    // rsETH
-    "0xc3eACf0612346366Db554C991D7858716db09f58",
-  ],
-  usdc: [
-    // satUSD
-    "0xb4818BB69478730EF4e33Cc068dD94278e2766cB",
-    // stargate USDC
-    "0xad11a8BEb98bbf61dbb1aa0F6d6F2ECD87b35afA",
-  ],
-  usdt: [
-    // VUSD
-    "0x7A06C4AeF988e7925575C50261297a946aD204A8",
-  ],
-};
-
-const addUsdRate = (prices) =>
-  function (stakeToken) {
-    // some tokens do not adjust to symbol, so they use this mapping instead
-    const symbol =
-      Object.keys(priceMaps).find((priceSymbol) =>
-        priceMaps[priceSymbol].includes(stakeToken.address),
-      ) || stakeToken.symbol;
-    return {
-      ...stakeToken,
-      priceSymbol: symbol.toUpperCase(),
-      usdRate: prices[symbol.toUpperCase()],
-    };
-  };
 
 /**
  * This functions the complete spreadsheet, and gets the last row with data.

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,4 +1,5 @@
 import { addUsdRate, getPrices } from "./prices";
+import { getLastRowWithData } from "./spreadsheets";
 import { getTokenList } from "./tokenList";
 import { addTokenMetadata } from "./tokens";
 
@@ -7,21 +8,6 @@ const stakeUrl = "https://subgraph.hemi.xyz/43111/staked";
 const usdSuffix = "_usd";
 // Skip Date and TVL columns
 const columnOffset = 2;
-
-/**
- * This functions the complete spreadsheet, and gets the last row with data.
- * As each stake snapshot takes one entire row, the last row + 1 will give the row
- * where to paste the next stake snapshot.
- */
-function getLastRowWithData(sheet) {
-  const rowsWithValue = sheet
-    .getRange("A:A")
-    .getValues()
-    .map((row) => row[0])
-    .filter(String); // Remove empty rows
-  // Spreadsheets are 1-indexed, so they match the length
-  return rowsWithValue.length || 1;
-}
 
 function getDate() {
   const now = new Date();

--- a/src/tokenList.js
+++ b/src/tokenList.js
@@ -1,0 +1,8 @@
+const tokenListUrl =
+  "https://raw.githubusercontent.com/hemilabs/token-list/master/src/hemi.tokenlist.json";
+
+export const getTokenList = () =>
+  JSON.parse(UrlFetchApp.fetch(tokenListUrl).getContentText()).tokens.filter(
+    // Metrics only use Mainnet data
+    (token) => token.chainId === 43111,
+  );

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,0 +1,24 @@
+const EthOnL2Address = "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000";
+
+export const addTokenMetadata = (tokenList) =>
+  function (token) {
+    // handle native token case
+    if (token.id === EthOnL2Address) {
+      return {
+        ...token,
+        address: token.id,
+        decimals: 18,
+        symbol: "ETH",
+      };
+    }
+    const { address, decimals, symbol } = tokenList.find(
+      (tokenDefinition) =>
+        tokenDefinition.address.toLowerCase() === token.id.toLowerCase(),
+    );
+    return {
+      ...token,
+      address,
+      decimals,
+      symbol,
+    };
+  };


### PR DESCRIPTION
Related to #3

This PR works as a setup for adding the tunneling metrics. Some of the functions used in the TVL metric will be reused for tunneling, so this PR splits them into separate files for better reusability. You can review it commit by commit, but basically, each commit moves a function somewhere else - no changes to the build output.

I'm sending this PR to get all of these changes out of the way before reviewing the tunneling one (which I'm testing at this moment).

I also moved the metric into a `createStakeTvl` to avoid having many functions in the global space in the build - they will now be inside the scope of the object returned by `createStakeTvl`