### PR TITLE
Move common requests into common.js

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,13 @@
+import { getPrices } from "./prices";
+import { getTokenList } from "./tokenList";
+
+export const getCommonData = function () {
+  const prices = getPrices();
+
+  const tokenList = getTokenList();
+
+  return {
+    prices,
+    tokenList,
+  };
+};

--- a/src/evmTunnelVolume.js
+++ b/src/evmTunnelVolume.js
@@ -1,13 +1,12 @@
 import { constants } from "./constants";
 import { subtractDays } from "./date";
-import { addUsdRate, getPrices } from "./prices";
+import { addUsdRate } from "./prices";
 import {
   generateTokenHeaders,
   getLastRowWithData,
   writeHeaders,
 } from "./spreadsheets";
 import { requestSubgraph, subgraphPaginate } from "./subgraph";
-import { getTokenList } from "./tokenList";
 import { addTokenMetadata } from "./tokens";
 
 export const createEvmTunnelingVolume = function () {
@@ -198,7 +197,7 @@ export const createEvmTunnelingVolume = function () {
     return `=${inflowCell} - ${outflowCell}`;
   };
 
-  const addEvmTunnelVolume = function () {
+  const addEvmTunnelVolume = function ({ prices, tokenList }) {
     const inflowPrefix = "Inflow";
     const outflowPrefix = "Outflow";
     const tunnelVolumeSheet =
@@ -207,10 +206,6 @@ export const createEvmTunnelingVolume = function () {
       );
 
     const lastRow = getLastRowWithData(tunnelVolumeSheet);
-
-    const prices = getPrices();
-
-    const tokenList = getTokenList();
 
     const fromTimestamp = getFromTimestamp();
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@
 // As part of the build, everything ends up in a big plain javascript file (out.js).
 // That script can be copied into a Google App Script and should run without any change.
 // The output script is not minified to it is easier to debug in the Google App Script editor.
+import { getCommonData } from "./common";
 import { createEvmTunnelingVolume } from "./evmTunnelVolume";
 import { createStakeTvl } from "./stakeTvl";
 
@@ -13,11 +14,12 @@ import { createStakeTvl } from "./stakeTvl";
 // Google App Script needs the declaration only to use it as an entry point
 // eslint-disable-next-line no-unused-vars
 function updateMetrics() {
+  const common = getCommonData();
   const { addEvmTunnelVolume } = createEvmTunnelingVolume();
   const { addTvlInfo } = createStakeTvl();
 
   // Update the Stake TVL
-  addTvlInfo();
+  addTvlInfo(common);
   // Add daily tunnel information from Ethereum
-  addEvmTunnelVolume();
+  addEvmTunnelVolume(common);
 }

--- a/src/stakeTvl.js
+++ b/src/stakeTvl.js
@@ -1,12 +1,11 @@
 import { constants } from "./constants";
 import { getDate } from "./date";
-import { addUsdRate, getPrices } from "./prices";
+import { addUsdRate } from "./prices";
 import {
   generateTokenHeaders,
   getLastRowWithData,
   writeHeaders,
 } from "./spreadsheets";
-import { getTokenList } from "./tokenList";
 import { addTokenMetadata } from "./tokens";
 
 export const createStakeTvl = function () {
@@ -47,15 +46,12 @@ export const createStakeTvl = function () {
     return `=SUM(${startRange.getA1Notation()}:${endRange.getA1Notation()})`;
   }
 
-  function addTvlInfo() {
+  function addTvlInfo({ prices, tokenList }) {
     const stakeSheet =
       SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Stake TVL");
 
     // gather all the information we need
-    const prices = getPrices();
     const { staked } = JSON.parse(UrlFetchApp.fetch(stakeUrl).getContentText());
-
-    const tokenList = getTokenList();
 
     const stakeData = staked
       .map(addTokenMetadata(tokenList))


### PR DESCRIPTION
This PR moves 2 requests into `common.js`: The prices API call and the Token list call. Besides saving some time (Because requests are sync, and these are used in the 2 metrics calculated), there's another benefit: Particularly, the token list is an unauthenticated request to Github, and we know that in May Github added [rate limits to unauthenticated requests](https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/).   
This means we reduce the chances of getting the token list request to fail