### PR TITLE
Use UTC for date column in evm tunneling

### DIFF
--- a/src/evmTunnelVolume.js
+++ b/src/evmTunnelVolume.js
@@ -270,7 +270,7 @@ export const createEvmTunnelingVolume = function () {
 
     const values = [
       // Running today, show yesterday's data as the day is already complete
-      new Date(fromTimestamp * 1000),
+      new Date(fromTimestamp * 1000).toISOString().split("T")[0],
       // Difference of Inflows and Outflows
       getTotalVolumeCell({ lastRow, sheet: tunnelVolumeSheet }),
       // Inflow TVL formula


### PR DESCRIPTION
The EVM tunneling metrics were showing the incorrect Date column. This was because by using a plain `Date` object, it was converted into a time-zoned version of the date, which would render the day before. This PR fixes that  

Related to #3 