### PR TITLE
Update prices API url

### DIFF
--- a/src/prices.js
+++ b/src/prices.js
@@ -1,4 +1,4 @@
-const pricesUrl = "https://token-prices.hemi.xyz/";
+const pricesUrl = "https://portal-api.hemi.xyz/prices";
 
 export const getPrices = function () {
   const { prices } = JSON.parse(UrlFetchApp.fetch(pricesUrl).getContentText());


### PR DESCRIPTION
After some APIs were unified in https://github.com/hemilabs/ui-monorepo/pull/1364, the Token Prices needed to be updated. This PR does that